### PR TITLE
 [FIX] i18n: word "False" now is not "Ложный" in russian

### DIFF
--- a/packages/rocketchat-i18n/i18n/ru.i18n.json
+++ b/packages/rocketchat-i18n/i18n/ru.i18n.json
@@ -720,7 +720,7 @@
   "External_Service": "Внешний сервис",
   "External_Queue_Service_URL": "URL внешнего сервера очередей",
   "Facebook_Page": "Страница Facebook",
-  "False": "Ложный",
+  "False": "Нет",
   "Favorite_Rooms": "Включить избранные каналы",
   "Favorites": "Избранное",
   "Features_Enabled": "Доступные функции",


### PR DESCRIPTION
it was is a very ugly-looking translation to russian, as my english knowledge
